### PR TITLE
Fix extra margin on office image

### DIFF
--- a/_sass/components/Workplace.scss
+++ b/_sass/components/Workplace.scss
@@ -25,6 +25,7 @@
 
   &__office {
     left: 50%;
+    margin-left: -30px;
     padding-bottom: 60px;
     position: relative;
     transform: translateX(-50%);


### PR DESCRIPTION
Just noticed this over the weekend. An extra margin on the right side of the office image causes a horizontal scroll on mobile.